### PR TITLE
examples: add support for wioterminal

### DIFF
--- a/examples/basic/main.go
+++ b/examples/basic/main.go
@@ -6,21 +6,11 @@ import (
 	"machine"
 	"time"
 
-	"tinygo.org/x/drivers/ili9341"
 	"tinygo.org/x/tinyterm"
 	"tinygo.org/x/tinyterm/fonts/proggy"
 )
 
 var (
-	display = ili9341.NewParallel(
-		machine.LCD_DATA0,
-		machine.TFT_WR,
-		machine.TFT_DC,
-		machine.TFT_CS,
-		machine.TFT_RESET,
-		machine.TFT_RD,
-	)
-
 	terminal = tinyterm.NewTerminal(display)
 
 	black = color.RGBA{0, 0, 0, 255}
@@ -34,14 +24,13 @@ var (
 
 func main() {
 
-	machine.TFT_BACKLIGHT.Configure(machine.PinConfig{machine.PinOutput})
+	backlight.Configure(machine.PinConfig{machine.PinOutput})
 
-	display.Configure(ili9341.Config{})
 	width, height := display.Size()
 	_, _ = width, height
 
 	display.FillScreen(black)
-	machine.TFT_BACKLIGHT.High()
+	backlight.High()
 
 	terminal.Configure(&tinyterm.Config{
 		Font:       font,

--- a/examples/basic/pyportal.go
+++ b/examples/basic/pyportal.go
@@ -1,0 +1,26 @@
+// +build pyportal
+
+package main
+
+import (
+	"machine"
+
+	"tinygo.org/x/drivers/ili9341"
+)
+
+var (
+	display = ili9341.NewParallel(
+		machine.LCD_DATA0,
+		machine.TFT_WR,
+		machine.TFT_DC,
+		machine.TFT_CS,
+		machine.TFT_RESET,
+		machine.TFT_RD,
+	)
+
+	backlight = machine.TFT_BACKLIGHT
+)
+
+func init() {
+	display.Configure(ili9341.Config{})
+}

--- a/examples/basic/wioterminal.go
+++ b/examples/basic/wioterminal.go
@@ -1,0 +1,30 @@
+// +build wioterminal
+
+package main
+
+import (
+	"machine"
+
+	"tinygo.org/x/drivers/ili9341"
+)
+
+var (
+	display = ili9341.NewSPI(
+		machine.SPI3,
+		machine.LCD_DC,
+		machine.LCD_SS_PIN,
+		machine.LCD_RESET,
+	)
+
+	backlight = machine.LCD_BACKLIGHT
+)
+
+func init() {
+	machine.SPI3.Configure(machine.SPIConfig{
+		SCK:       machine.LCD_SCK_PIN,
+		SDO:       machine.LCD_SDO_PIN,
+		SDI:       machine.LCD_SDI_PIN,
+		Frequency: 40000000,
+	})
+	display.Configure(ili9341.Config{})
+}

--- a/examples/colors/main.go
+++ b/examples/colors/main.go
@@ -7,39 +7,27 @@ import (
 	"strings"
 	"time"
 
-	"tinygo.org/x/drivers/ili9341"
-
 	"tinygo.org/x/tinyterm"
 	"tinygo.org/x/tinyterm/fonts/proggy"
 )
 
 var (
-	display = ili9341.NewParallel(
-		machine.LCD_DATA0,
-		machine.TFT_WR,
-		machine.TFT_DC,
-		machine.TFT_CS,
-		machine.TFT_RESET,
-		machine.TFT_RD,
-	)
-
 	terminal = tinyterm.NewTerminal(display)
 
-	font = &proggy.TinySZ8pt8b
+	font = &proggy.TinySZ8pt7b
 )
 
 func main() {
 
 	time.Sleep(time.Second)
 
-	machine.TFT_BACKLIGHT.Configure(machine.PinConfig{machine.PinOutput})
+	backlight.Configure(machine.PinConfig{machine.PinOutput})
 
-	display.Configure(ili9341.Config{})
 	width, height := display.Size()
 	_, _ = width, height
 
 	display.FillScreen(color.RGBA{0, 0, 0, 255})
-	machine.TFT_BACKLIGHT.High()
+	backlight.High()
 
 	terminal.Configure(&tinyterm.Config{
 		Font:       font,

--- a/examples/colors/pyportal.go
+++ b/examples/colors/pyportal.go
@@ -1,0 +1,26 @@
+// +build pyportal
+
+package main
+
+import (
+	"machine"
+
+	"tinygo.org/x/drivers/ili9341"
+)
+
+var (
+	display = ili9341.NewParallel(
+		machine.LCD_DATA0,
+		machine.TFT_WR,
+		machine.TFT_DC,
+		machine.TFT_CS,
+		machine.TFT_RESET,
+		machine.TFT_RD,
+	)
+
+	backlight = machine.TFT_BACKLIGHT
+)
+
+func init() {
+	display.Configure(ili9341.Config{})
+}

--- a/examples/colors/wioterminal.go
+++ b/examples/colors/wioterminal.go
@@ -1,0 +1,30 @@
+// +build wioterminal
+
+package main
+
+import (
+	"machine"
+
+	"tinygo.org/x/drivers/ili9341"
+)
+
+var (
+	display = ili9341.NewSPI(
+		machine.SPI3,
+		machine.LCD_DC,
+		machine.LCD_SS_PIN,
+		machine.LCD_RESET,
+	)
+
+	backlight = machine.LCD_BACKLIGHT
+)
+
+func init() {
+	machine.SPI3.Configure(machine.SPIConfig{
+		SCK:       machine.LCD_SCK_PIN,
+		SDO:       machine.LCD_SDO_PIN,
+		SDI:       machine.LCD_SDI_PIN,
+		Frequency: 40000000,
+	})
+	display.Configure(ili9341.Config{})
+}


### PR DESCRIPTION
`tinyterm` is very good.
Added wioterminal support.
The font in the examples of colors is probably wrong, so I fixed it.

![image](https://user-images.githubusercontent.com/9251039/121027176-b8630c00-c7e1-11eb-800d-51dfc9895e9f.png)
