### PR TITLE
feature: add support for Badger2040

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ TARGET = build/examples_basic.hex \
 		 build/examples_basic_gopher_badge.hex \
 		 build/examples_basic_pybadge.hex \
 		 build/examples_basic_wioterminal.hex \
+		 build/examples_basic_badger2040.hex \
 		 build/examples_colors.hex \
 		 build/examples_httpclient.hex
 .PHONY: smoketest $(TARGET)
@@ -48,6 +49,10 @@ build/examples_basic_pybadge.hex:
 
 build/examples_basic_wioterminal.hex:
 	$(TINYGO) build -size short -o $@ -target=wioterminal ./examples/basic
+	@$(MD5SUM) $@
+
+build/examples_basic_badger2040.hex:
+	$(TINYGO) build -size short -o $@ -target=badger2040 ./examples/basic
 	@$(MD5SUM) $@
 
 build/examples_colors.hex:

--- a/examples/basic/main.go
+++ b/examples/basic/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"image/color"
 	"time"
 
 	"tinygo.org/x/tinyfont/proggy"
@@ -11,12 +10,6 @@ import (
 )
 
 var (
-	black = color.RGBA{0, 0, 0, 255}
-	white = color.RGBA{255, 255, 255, 255}
-	red   = color.RGBA{255, 0, 0, 255}
-	blue  = color.RGBA{0, 0, 255, 255}
-	green = color.RGBA{0, 255, 0, 255}
-
 	font = &proggy.TinySZ8pt7b
 )
 
@@ -25,13 +18,15 @@ func main() {
 	terminal := tinyterm.NewTerminal(display)
 
 	terminal.Configure(&tinyterm.Config{
-		Font:       font,
-		FontHeight: 10,
-		FontOffset: 6,
+		Font:              font,
+		FontHeight:        10,
+		FontOffset:        6,
+		UseSoftwareScroll: initdisplay.NeedsSoftwareScroll(),
 	})
 	for {
-		time.Sleep(50 * time.Millisecond)
-		fmt.Fprintf(terminal, "\ntime: %d", time.Now().UnixNano())
-	}
+		time.Sleep(time.Second)
 
+		fmt.Fprintf(terminal, "\ntime: %d", time.Now().UnixNano())
+		display.Display()
+	}
 }

--- a/examples/initdisplay/badger2040.go
+++ b/examples/initdisplay/badger2040.go
@@ -1,0 +1,37 @@
+//go:build badger2040 || badger2040_w
+
+package initdisplay
+
+import (
+	"machine"
+
+	"tinygo.org/x/drivers/uc8151"
+	"tinygo.org/x/tinyterm"
+)
+
+func InitDisplay() tinyterm.Displayer {
+	led3v3 := machine.ENABLE_3V3
+	led3v3.Configure(machine.PinConfig{Mode: machine.PinOutput})
+	led3v3.High()
+
+	machine.SPI0.Configure(machine.SPIConfig{
+		Frequency: 12000000,
+		SCK:       machine.EPD_SCK_PIN,
+		SDO:       machine.EPD_SDO_PIN,
+	})
+
+	display := uc8151.New(machine.SPI0, machine.EPD_CS_PIN, machine.EPD_DC_PIN, machine.EPD_RESET_PIN, machine.EPD_BUSY_PIN)
+	display.Configure(uc8151.Config{
+		Speed:       uc8151.TURBO,
+		FlickerFree: true,
+		Rotation:    uc8151.ROTATION_270,
+	})
+
+	display.ClearDisplay()
+
+	return &display
+}
+
+func NeedsSoftwareScroll() bool {
+	return true
+}

--- a/examples/initdisplay/clue.go
+++ b/examples/initdisplay/clue.go
@@ -36,3 +36,7 @@ func InitDisplay() tinyterm.Displayer {
 
 	return &display
 }
+
+func NeedsSoftwareScroll() bool {
+	return false
+}

--- a/examples/initdisplay/gopher-badge.go
+++ b/examples/initdisplay/gopher-badge.go
@@ -30,3 +30,7 @@ func InitDisplay() tinyterm.Displayer {
 
 	return &display
 }
+
+func NeedsSoftwareScroll() bool {
+	return false
+}

--- a/examples/initdisplay/pybadge.go
+++ b/examples/initdisplay/pybadge.go
@@ -26,3 +26,7 @@ func InitDisplay() tinyterm.Displayer {
 
 	return &display
 }
+
+func NeedsSoftwareScroll() bool {
+	return false
+}

--- a/examples/initdisplay/pyportal.go
+++ b/examples/initdisplay/pyportal.go
@@ -33,3 +33,7 @@ func InitDisplay() tinyterm.Displayer {
 
 	return display
 }
+
+func NeedsSoftwareScroll() bool {
+	return false
+}

--- a/examples/initdisplay/wioterminal.go
+++ b/examples/initdisplay/wioterminal.go
@@ -38,3 +38,7 @@ func InitDisplay() tinyterm.Displayer {
 
 	return display
 }
+
+func NeedsSoftwareScroll() bool {
+	return false
+}

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module tinygo.org/x/tinyterm
 go 1.18
 
 require (
-	tinygo.org/x/drivers v0.26.1-0.20231206190939-3fabdc5c9680
+	tinygo.org/x/drivers v0.28.1-0.20241027232331-f12454d4f7be
 	tinygo.org/x/tinyfont v0.4.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,6 @@
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaUGG7oYTSPP8MxqL4YI3kZKwcP4=
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
-tinygo.org/x/drivers v0.26.1-0.20231206190939-3fabdc5c9680 h1:S7FwtuTMSkyEjF1cgl3AFlnBR940GYgCMSADm0U8e7o=
-tinygo.org/x/drivers v0.26.1-0.20231206190939-3fabdc5c9680/go.mod h1:q/mU8G/wz821p8xXqbkBACOlmZFDHXd//DnYnCW+dDQ=
+tinygo.org/x/drivers v0.28.1-0.20241027232331-f12454d4f7be h1:cIDFZYnZQSjzvw1LEht5Av1YZ2Aw6mJuNH31l+uIAv0=
+tinygo.org/x/drivers v0.28.1-0.20241027232331-f12454d4f7be/go.mod h1:q/mU8G/wz821p8xXqbkBACOlmZFDHXd//DnYnCW+dDQ=
 tinygo.org/x/tinyfont v0.4.0 h1:XexPKEKiHInf6p4CMCJwsIheVPY0T46HUs6ictYyZfE=
 tinygo.org/x/tinyfont v0.4.0/go.mod h1:7nVj3j3geqBoPDzpFukAhF1C8AP9YocMsZy0HSAcGCA=


### PR DESCRIPTION
This PR adds support for the Badger2040 and Badger2040-W boards.

Requires that https://github.com/tinygo-org/drivers/pull/711 is merged into drivers before it will work correcttly.