### PR TITLE
feature: add displays subpackage

### DIFF
--- a/displays/badger2040.go
+++ b/displays/badger2040.go
@@ -1,6 +1,6 @@
 //go:build badger2040 || badger2040_w
 
-package initdisplay
+package displays
 
 import (
 	"machine"
@@ -9,7 +9,7 @@ import (
 	"tinygo.org/x/tinyterm"
 )
 
-func InitDisplay() tinyterm.Displayer {
+func Init() tinyterm.Displayer {
 	led3v3 := machine.ENABLE_3V3
 	led3v3.Configure(machine.PinConfig{Mode: machine.PinOutput})
 	led3v3.High()

--- a/displays/clue.go
+++ b/displays/clue.go
@@ -1,6 +1,6 @@
 //go:build clue_alpha
 
-package initdisplay
+package displays
 
 import (
 	"image/color"
@@ -10,7 +10,7 @@ import (
 	"tinygo.org/x/tinyterm"
 )
 
-func InitDisplay() tinyterm.Displayer {
+func Init() tinyterm.Displayer {
 	machine.SPI1.Configure(machine.SPIConfig{
 		Frequency: 8000000,
 		SCK:       machine.TFT_SCK,

--- a/displays/gopher-badge.go
+++ b/displays/gopher-badge.go
@@ -1,6 +1,6 @@
 //go:build gopher_badge
 
-package initdisplay
+package displays
 
 import (
 	"image/color"
@@ -10,7 +10,7 @@ import (
 	"tinygo.org/x/tinyterm"
 )
 
-func InitDisplay() tinyterm.Displayer {
+func Init() tinyterm.Displayer {
 	machine.SPI0.Configure(machine.SPIConfig{
 		Frequency: 8000000,
 		Mode:      0,

--- a/displays/pybadge.go
+++ b/displays/pybadge.go
@@ -1,6 +1,6 @@
 //go:build pybadge
 
-package initdisplay
+package displays
 
 import (
 	"image/color"
@@ -10,7 +10,7 @@ import (
 	"tinygo.org/x/tinyterm"
 )
 
-func InitDisplay() tinyterm.Displayer {
+func Init() tinyterm.Displayer {
 	machine.SPI1.Configure(machine.SPIConfig{
 		SCK:       machine.SPI1_SCK_PIN,
 		SDO:       machine.SPI1_SDO_PIN,
@@ -20,7 +20,7 @@ func InitDisplay() tinyterm.Displayer {
 
 	display := st7735.New(machine.SPI1, machine.TFT_RST, machine.TFT_DC, machine.TFT_CS, machine.TFT_LITE)
 	display.Configure(st7735.Config{
-		Rotation: st7735.ROTATION_180,
+		Rotation: st7735.ROTATION_90,
 	})
 	display.FillScreen(color.RGBA{0, 0, 0, 255})
 

--- a/displays/pyportal.go
+++ b/displays/pyportal.go
@@ -1,6 +1,6 @@
-//go:build wioterminal
+//go:build pyportal
 
-package initdisplay
+package displays
 
 import (
 	"image/color"
@@ -10,24 +10,19 @@ import (
 	"tinygo.org/x/tinyterm"
 )
 
-func InitDisplay() tinyterm.Displayer {
-	machine.SPI3.Configure(machine.SPIConfig{
-		SCK:       machine.LCD_SCK_PIN,
-		SDO:       machine.LCD_SDO_PIN,
-		SDI:       machine.LCD_SDI_PIN,
-		Frequency: 40000000,
-	})
+func Init() tinyterm.Displayer {
+	display := ili9341.NewParallel(
+		machine.LCD_DATA0,
+		machine.TFT_WR,
+		machine.TFT_DC,
+		machine.TFT_CS,
+		machine.TFT_RESET,
+		machine.TFT_RD,
+	)
 
 	// configure backlight
-	backlight := machine.LCD_BACKLIGHT
+	backlight := machine.TFT_BACKLIGHT
 	backlight.Configure(machine.PinConfig{machine.PinOutput})
-
-	display := ili9341.NewSPI(
-		machine.SPI3,
-		machine.LCD_DC,
-		machine.LCD_SS_PIN,
-		machine.LCD_RESET,
-	)
 
 	// configure display
 	display.Configure(ili9341.Config{})

--- a/displays/wioterminal.go
+++ b/displays/wioterminal.go
@@ -1,6 +1,6 @@
-//go:build pyportal
+//go:build wioterminal
 
-package initdisplay
+package displays
 
 import (
 	"image/color"
@@ -10,19 +10,24 @@ import (
 	"tinygo.org/x/tinyterm"
 )
 
-func InitDisplay() tinyterm.Displayer {
-	display := ili9341.NewParallel(
-		machine.LCD_DATA0,
-		machine.TFT_WR,
-		machine.TFT_DC,
-		machine.TFT_CS,
-		machine.TFT_RESET,
-		machine.TFT_RD,
-	)
+func Init() tinyterm.Displayer {
+	machine.SPI3.Configure(machine.SPIConfig{
+		SCK:       machine.LCD_SCK_PIN,
+		SDO:       machine.LCD_SDO_PIN,
+		SDI:       machine.LCD_SDI_PIN,
+		Frequency: 40000000,
+	})
 
 	// configure backlight
-	backlight := machine.TFT_BACKLIGHT
+	backlight := machine.LCD_BACKLIGHT
 	backlight.Configure(machine.PinConfig{machine.PinOutput})
+
+	display := ili9341.NewSPI(
+		machine.SPI3,
+		machine.LCD_DC,
+		machine.LCD_SS_PIN,
+		machine.LCD_RESET,
+	)
 
 	// configure display
 	display.Configure(ili9341.Config{})

--- a/examples/basic/main.go
+++ b/examples/basic/main.go
@@ -27,6 +27,6 @@ func main() {
 		time.Sleep(time.Second)
 
 		fmt.Fprintf(terminal, "\ntime: %d", time.Now().UnixNano())
-		display.Display()
+		terminal.Display()
 	}
 }

--- a/examples/basic/main.go
+++ b/examples/basic/main.go
@@ -6,7 +6,7 @@ import (
 
 	"tinygo.org/x/tinyfont/proggy"
 	"tinygo.org/x/tinyterm"
-	"tinygo.org/x/tinyterm/examples/initdisplay"
+	"tinygo.org/x/tinyterm/displays"
 )
 
 var (
@@ -14,14 +14,14 @@ var (
 )
 
 func main() {
-	display := initdisplay.InitDisplay()
+	display := displays.Init()
 	terminal := tinyterm.NewTerminal(display)
 
 	terminal.Configure(&tinyterm.Config{
 		Font:              font,
 		FontHeight:        10,
 		FontOffset:        6,
-		UseSoftwareScroll: initdisplay.NeedsSoftwareScroll(),
+		UseSoftwareScroll: displays.NeedsSoftwareScroll(),
 	})
 	for {
 		time.Sleep(time.Second)

--- a/examples/colors/main.go
+++ b/examples/colors/main.go
@@ -7,7 +7,7 @@ import (
 
 	"tinygo.org/x/tinyfont/proggy"
 	"tinygo.org/x/tinyterm"
-	"tinygo.org/x/tinyterm/examples/initdisplay"
+	"tinygo.org/x/tinyterm/displays"
 )
 
 var (
@@ -15,7 +15,7 @@ var (
 )
 
 func main() {
-	display := initdisplay.InitDisplay()
+	display := displays.Init()
 	terminal := tinyterm.NewTerminal(display)
 
 	terminal.Configure(&tinyterm.Config{

--- a/examples/colors/main.go
+++ b/examples/colors/main.go
@@ -49,6 +49,8 @@ func main() {
 		}
 		terminal.Write([]byte(strings.Repeat(" ", 12) + "|\n"))
 		terminal.Write([]byte("   " + strings.Repeat("\xaf", 36) + "\n"))
+
+		terminal.Display()
 		time.Sleep(5 * time.Second)
 	}
 

--- a/examples/httpclient/main.go
+++ b/examples/httpclient/main.go
@@ -90,6 +90,8 @@ func main() {
 
 		cnt++
 		fmt.Fprintf(terminal, "-------- %d --------\r\n", cnt)
+
+		terminal.Display()
 		time.Sleep(10 * time.Second)
 	}
 }

--- a/examples/httpclient/main.go
+++ b/examples/httpclient/main.go
@@ -20,7 +20,7 @@ import (
 	"tinygo.org/x/drivers/netlink/probe"
 	"tinygo.org/x/tinyfont/proggy"
 	"tinygo.org/x/tinyterm"
-	"tinygo.org/x/tinyterm/examples/initdisplay"
+	"tinygo.org/x/tinyterm/displays"
 )
 
 var (
@@ -39,7 +39,7 @@ var (
 )
 
 func main() {
-	display := initdisplay.InitDisplay()
+	display := displays.Init()
 	terminal := tinyterm.NewTerminal(display)
 
 	terminal.Configure(&tinyterm.Config{

--- a/tinyterm.go
+++ b/tinyterm.go
@@ -121,6 +121,12 @@ func (t *Terminal) Println(args ...interface{}) (n int, err error) {
 	return fmt.Fprintln(t, args...)
 }
 
+// Display the terminal on the display. Must be called after writing to the
+// terminal to see the changes.
+func (t *Terminal) Display() {
+	t.display.Display()
+}
+
 type state uint8
 
 const (


### PR DESCRIPTION
This PR adds a new subpackage named `displays` intended to make it easier to use one of the supported display devices.

It also adds a `terminal.Display()` method that is just a wrapper for calling the display's method of the same name. This is required for displays such as e-ink or slow OLED screens.

Even though `display.Display()` is a no-op on many displays, this will ensure compatibility with these slower displays.

This PR requires #12 be merged first and then this one rebased.