### PR TITLE
feature: add SetRotation() to tinyterm Displayer interface

### DIFF
--- a/tinyterm.go
+++ b/tinyterm.go
@@ -28,6 +28,7 @@ type Displayer interface {
 	drivers.Displayer
 	FillRectangle(x, y, width, height int16, c color.RGBA) error
 	SetScroll(line int16)
+	SetRotation(rotation drivers.Rotation) error
 }
 
 // Terminal is a terminal interface that can be used on any display


### PR DESCRIPTION
This PR adds the `SetRotation()` function to the `tinyterm.Displayer` interface, to make it a little easier to adjust in actual use.